### PR TITLE
Added an implementation of a comparable Key Value Pair.

### DIFF
--- a/DataStructures/ConcurrentPriorityQueue.cs
+++ b/DataStructures/ConcurrentPriorityQueue.cs
@@ -11,8 +11,8 @@ namespace DataStructures
     /// Priority is defined by comparing elements, so to separate priority from value use
     /// KeyValuePair or a custom class and provide corresponding Comparer.
     /// </summary>
-    /// <typeparam name="T">Any comparable type</typeparam>
-    public class ConcurrentPriorityQueue<T> : PriorityQueue<T>, IProducerConsumerCollection<T>, IDisposable where T : IComparable<T>
+    /// <typeparam name="T">Any comparable type, either through a specified Comparer or implementing IComparable&lt;<typeparamref name="T"/>&gt;</typeparam>
+    public class ConcurrentPriorityQueue<T> : PriorityQueue<T>, IProducerConsumerCollection<T>, IDisposable
     {
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
 
@@ -31,6 +31,7 @@ namespace DataStructures
         /// <param name="capacity">Initial capacity</param>
         /// <param name="comparer">Custom comparer to compare elements. If omitted - default will be used.</param>
         /// <exception cref="ArgumentOutOfRangeException">Throws <see cref="ArgumentOutOfRangeException"/> when capacity is less than or equal to zero.</exception>
+        /// <exception cref="ArgumentException">Throws <see cref="ArgumentException"/> when comparer is null and <typeparamref name="T"/> is not comparable</exception>
         public ConcurrentPriorityQueue(int capacity, IComparer<T> comparer = null) : base(capacity, comparer)
         {
             

--- a/DataStructures/ConcurrentSkipList.cs
+++ b/DataStructures/ConcurrentSkipList.cs
@@ -6,7 +6,6 @@ using System.Threading;
 namespace DataStructures
 {
     public class ConcurrentSkipList<T> : SkipList<T>, IProducerConsumerCollection<T>, IDisposable
-        where T : IComparable<T>
     {
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();
 

--- a/DataStructures/DataStructures.csproj
+++ b/DataStructures/DataStructures.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConcurrentPriorityQueue.cs" />
+    <Compile Include="KeyValuePairComparer.cs" />
     <Compile Include="PriorityQueue.cs" />
     <Compile Include="SkipList.cs" />
     <Compile Include="ConcurrentSkipList.cs" />

--- a/DataStructures/KeyValuePairComparer.cs
+++ b/DataStructures/KeyValuePairComparer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace DataStructures
+{
+    /// <summary>
+    /// A Comparer for KeyValuePair that compares keys
+    /// </summary>
+    /// <typeparam name="TKey">Any comparable type</typeparam>
+    /// <typeparam name="TValue">Any type</typeparam>
+    public class KeyValuePairComparer<TKey, TValue> : IComparer<KeyValuePair<TKey, TValue>> where TKey : IComparable<TKey>
+    {
+        private readonly IComparer<TKey> keyComparer;
+
+        /// <summary>
+        /// Create a Comparer for KeyValuePair with an optional comparer for <typeparamref name="TKey"/>
+        /// </summary>
+        /// <param name="keyComparer">Custom comparer to compare Keys. Uses default if omitted</param>
+        public KeyValuePairComparer(IComparer<TKey> keyComparer = null)
+        {
+            this.keyComparer = keyComparer ?? Comparer<TKey>.Default;
+        }
+
+        /// <summary>
+        /// Compares two KeyValuePairs and returns a value indicating whether one is less than, equal to, or greater than the other.
+        /// </summary>
+        /// <param name="x">The first KeyValuePair to compare</param>
+        /// <param name="y">The second KeyValuePair to compare</param>
+        /// <returns>A signed integer that indicates the relative values of <paramref name="x"/> and <paramref name="y"/>, as shown in the following table.Value Meaning Less than zero<paramref name="x"/> is less than <paramref name="y"/>.Zero<paramref name="x"/> equals <paramref name="y"/>.Greater than zero<paramref name="x"/> is greater than <paramref name="y"/>.</returns>
+        public int Compare(KeyValuePair<TKey, TValue> x, KeyValuePair<TKey, TValue> y)
+        {
+            return keyComparer.Compare(x.Key, y.Key);
+        }
+    }
+}

--- a/DataStructures/PriorityQueue.cs
+++ b/DataStructures/PriorityQueue.cs
@@ -10,8 +10,8 @@ namespace DataStructures
     /// Priority is defined by comparing elements, so to separate priority from value use
     /// KeyValuePair or a custom class and provide corresponding Comparer.
     /// </summary>
-    /// <typeparam name="T">Any comparable type</typeparam>
-    public class PriorityQueue<T> : ICollection<T> where T : IComparable<T>
+    /// <typeparam name="T">Any comparable type, either through a specified Comparer or implementing IComparable&lt;<typeparamref name="T"/>&gt;</typeparam>
+    public class PriorityQueue<T> : ICollection<T>
     {
         private readonly IComparer<T> _comparer;
         internal T[] _heap;
@@ -36,9 +36,18 @@ namespace DataStructures
         /// <param name="capacity">Initial capacity</param>
         /// <param name="comparer">Custom comparer to compare elements. If omitted - default will be used.</param>
         /// <exception cref="ArgumentOutOfRangeException">Throws <see cref="ArgumentOutOfRangeException"/> when capacity is less than or equal to zero.</exception>
+        /// <exception cref="ArgumentException">Throws <see cref="ArgumentException"/> when comparer is null and <typeparamref name="T"/> is not comparable</exception>
         public PriorityQueue(int capacity, IComparer<T> comparer = null)
         {
             if (capacity <= 0) throw new ArgumentOutOfRangeException("capacity", "Expected capacity greater than zero.");
+
+            // If no comparer then T must be comparable
+            if (comparer == null &&
+                !(typeof(IComparable).IsAssignableFrom(typeof(T)) ||
+                  typeof(IComparable<T>).IsAssignableFrom(typeof(T))))
+            {
+                throw new ArgumentException("Must specify a comparer for types which are not comparable", "comparer");
+            }
 
             _comparer = comparer ?? Comparer<T>.Default;
             _shrinkBound = capacity / SHRINK_RATIO;

--- a/DataStructures/SkipList.cs
+++ b/DataStructures/SkipList.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 namespace DataStructures
 {
     public class SkipList<T> : ICollection<T>
-        where T : IComparable<T>
     {
         private const byte MAX_HEIGHT = 32;
         internal const byte HEIGHT_STEP = 4;
@@ -24,6 +23,14 @@ namespace DataStructures
 
         public SkipList(IComparer<T> comparer = null)
         {
+            // If no comparer then T must be comparable
+            if (comparer == null &&
+                !(typeof(IComparable).IsAssignableFrom(typeof(T)) ||
+                  typeof(IComparable<T>).IsAssignableFrom(typeof(T))))
+            {
+                throw new ArgumentException("Must specify a comparer for types which are not comparable", "comparer");
+            }
+
             _comparer = comparer ?? Comparer<T>.Default;
             _random = new Random();
 

--- a/Tests/FunctionalTests/FunctionalTests.csproj
+++ b/Tests/FunctionalTests/FunctionalTests.csproj
@@ -51,6 +51,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ConcurrentPriorityQueueTests.cs" />
+    <Compile Include="KeyValuePairComparerTests.cs" />
     <Compile Include="PriorityQueueTests.cs" />
     <Compile Include="SkipListTests.cs" />
     <Compile Include="Helpers\AssertEx.cs" />

--- a/Tests/FunctionalTests/KeyValuePairComparerTests.cs
+++ b/Tests/FunctionalTests/KeyValuePairComparerTests.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using DataStructures;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace FunctionalTests
+{
+    [TestClass]
+    public class KeyValuePairComparerTests
+    {
+        [TestMethod]
+        public void CompareEqual()
+        {
+            IComparer<KeyValuePair<int, string>> comparer = new KeyValuePairComparer<int, string>();
+            KeyValuePair<int, string> a = new KeyValuePair<int, string>(1, null);
+            KeyValuePair<int, string> b = new KeyValuePair<int, string>(1, "asdf");
+            Assert.AreEqual(0, comparer.Compare(a, b));
+        }
+
+        [TestMethod]
+        public void CompareGreater()
+        {
+            IComparer<KeyValuePair<int, string>> comparer = new KeyValuePairComparer<int, string>();
+            KeyValuePair<int, string> a = new KeyValuePair<int, string>(2, null);
+            KeyValuePair<int, string> b = new KeyValuePair<int, string>(1, "asdf");
+            Assert.AreEqual(1, comparer.Compare(a, b));
+        }
+
+        [TestMethod]
+        public void CompareNullSecondKey()
+        {
+            // All instances are greater than null (MSDN)
+            IComparer<KeyValuePair<string, string>> comparer = new KeyValuePairComparer<string, string>();
+            KeyValuePair<string, string> a = new KeyValuePair<string, string>("a", null);
+            KeyValuePair<string, string> b = new KeyValuePair<string, string>(null, "asdf");
+            Assert.AreEqual(1, comparer.Compare(a, b));
+        }
+
+        [TestMethod]
+        public void CompareNullFirstKey()
+        {
+            // All instances are greater than null (MSDN)
+            IComparer<KeyValuePair<string, string>> comparer = new KeyValuePairComparer<string, string>();
+            KeyValuePair<string, string> a = new KeyValuePair<string, string>(null, null);
+            KeyValuePair<string, string> b = new KeyValuePair<string, string>("a", "asdf");
+            Assert.AreEqual(-1, comparer.Compare(a, b));
+        }
+
+        [TestMethod]
+        public void CompareNullBothKeys()
+        {
+            IComparer<KeyValuePair<string, string>> comparer = new KeyValuePairComparer<string, string>();
+            KeyValuePair<string, string> a = new KeyValuePair<string, string>(null, null);
+            KeyValuePair<string, string> b = new KeyValuePair<string, string>(null, "asdf");
+            Assert.AreEqual(0, comparer.Compare(a, b));
+        }
+
+        [TestMethod]
+        public void CompareUsingCustomKeyComparer()
+        {
+            // Test that the custom comparer for the keys is used if supplied
+            IComparer<int> keyComparer = new ReverseIntComparer();
+            IComparer<KeyValuePair<int, string>> comparer = new KeyValuePairComparer<int, string>(keyComparer);
+            KeyValuePair<int, string> a = new KeyValuePair<int, string>(2, null);
+            KeyValuePair<int, string> b = new KeyValuePair<int, string>(1, "asdf");
+            Assert.AreEqual(-1, comparer.Compare(a, b));
+        }
+
+        #region Custom Comparers
+
+        private class ReverseIntComparer : IComparer<int>
+        {
+            public int Compare(int x, int y)
+            {
+                return -Comparer<int>.Default.Compare(x, y);
+            }
+        }
+
+        #endregion
+    }
+}

--- a/Tests/FunctionalTests/PriorityQueueTests.cs
+++ b/Tests/FunctionalTests/PriorityQueueTests.cs
@@ -252,5 +252,29 @@ namespace FunctionalTests
             Assert.AreEqual(25, target.Capacity);
             Assert.AreEqual(11, target.Count);
         }
+
+        [TestMethod]
+        public void UseCustomComparer()
+        {
+            PriorityQueue<KeyValuePair<int, string>> target =
+                new PriorityQueue<KeyValuePair<int, string>>(new KeyValuePairComparer<int, string>())
+            {
+                new KeyValuePair<int, string>(5, "1"),
+                new KeyValuePair<int, string>(7, "2"),
+                new KeyValuePair<int, string>(3, "3")
+            };
+
+            Assert.AreEqual("2", target.Take().Value);
+            Assert.AreEqual("1", target.Take().Value);
+            Assert.AreEqual("3", target.Take().Value);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof (ArgumentException))]
+        public void InstantiateWithNonComparableTypeAndNoComparer()
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            new PriorityQueue<KeyValuePair<int, string>>();
+        }
     }
 }

--- a/Tests/FunctionalTests/SkipListTests.cs
+++ b/Tests/FunctionalTests/SkipListTests.cs
@@ -374,5 +374,13 @@ namespace FunctionalTests
             Assert.AreEqual("2,3,4,5,6", string.Join(",", target.Range(2, 7, true, false)));
             Assert.AreEqual("3,4,5,6,7", string.Join(",", target.Range(2, 7, false, true)));
         }
+
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void InstantiateWithNonComparableTypeAndNoComparer()
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            new SkipList<KeyValuePair<int, string>>();
+        }
     }
 }


### PR DESCRIPTION
Can be used in data structures to give elements a different priority than their own implementation of IComparable<T> will give (as is the case in most use cases).

When switching my code from using your ConcurrentPriorityQueue library to your new DataStructures one, I needed something like this for my use case where the priority is separate from the element. Since that could be quite common, I thought this might be best included with the library.