### PR TITLE
Random was instantiated twice

### DIFF
--- a/DataStructures/SkipList.cs
+++ b/DataStructures/SkipList.cs
@@ -12,7 +12,7 @@ namespace DataStructures
         private readonly IComparer<T> _comparer;
 
         internal readonly Node _head;
-        private readonly Random _random = new Random();
+        private readonly Random _random;
         internal readonly Node _tail;
 
         internal byte _height;


### PR DESCRIPTION

`_random` was being instantiated twice:

`private readonly Random _random = new Random();`
and
`public SkipList(IComparer<T> comparer = null)
        {
            _random = new Random();
}`
To keep consistent, I removed field declaration assignment.
